### PR TITLE
update google chrome download URL

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -104,17 +104,14 @@ fi
 
 topic "Installing Google Chrome from the $channel channel."
 
-
 chrome_version=""
 
 # Detect requested channel or default to stable
 if [ -f $ENV_DIR/CHROME_VERSION ]; then
   chrome_version=$(cat $ENV_DIR/CHROME_VERSION)
 else
-  error "CHROME_VERSION can not be empty"
+  error "CHROME_VERSION cannot be empty"
 fi
-
-PACKAGES="$PACKAGES https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_$chrome_version-1_amd64.deb"
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
@@ -139,6 +136,15 @@ for PACKAGE in $PACKAGES; do
     apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
   fi
 done
+
+# new Google Chrome download location
+ZIP_URL="https://storage.googleapis.com/chrome-for-testing-public/$chrome_version/linux64/chrome-linux64.zip"
+ZIP_LOCATION="$BUILD_DIR/chrome.zip"
+
+topic "Pulling down Chrome version $chrome_version from $ZIP_URL"
+curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}" | indent
+unzip -q -o "$ZIP_LOCATION" -d "$BUILD_DIR" | indent
+rm -f "$ZIP_LOCATION"
 
 mkdir -p $BUILD_DIR/.apt
 


### PR DESCRIPTION
[update google chrome download URL](https://github.com/Maverick-Solutions-NC/heroku-buildpack-google-chrome/pull/1/commits/1ae65e124aca50fa48f237ec46fda6e23c0ce37e) 
```
Starting on 7/23/24, our Heroku builds were failing, because it could not retrieve the specified chrome version
using the dl.google.com URL structure. While I couldn't find a specific changelog that pointed to this URL no
longer working, Andy from RM helped me find the list of supported Chrome versions and their download paths here:
https://github.com/GoogleChromeLabs/chrome-for-testing/blob/main/data/known-good-versions-with-downloads.json#L4977

Since we were using a forked copy of the heroku-buildpack-google-chrome repo that pointed to the old URL structure,
I created a forked copy under the Maverick-Solutions-NC org and updated the path to point to the right one.
However, it does point to a .zip file vs. a .deb file, so I copied some commands from the heroku version of the
buildpack to unzip the file: https://github.com/heroku/heroku-buildpack-chromedriver/blob/master/bin/compile#L66C1-L73C1

Note that we will probably want to host our own version of the v116, so that in the future, if this version ever
gets deprecated, we can still have access to it through our own hosted version. However, a better short-term goal
is to figure out how to update our Chrome version to a more recent one, when time permits.
```